### PR TITLE
clarification to non-webpack project docs

### DIFF
--- a/docs/Webpack.md
+++ b/docs/Webpack.md
@@ -117,8 +117,7 @@ npm install --save-dev babel-loader
 
 > **Note:** If your project doesn’t use webpack you still need add webpack loaders for your files, otherwise Styleguidist won’t be able to load your code.
 
-Then, create a webpack config, `webpack.config.js`:
-
+Then, add a `webpackConfig` section to your `styleguide.config.js` 
 ```js
 module.exports = {
   webpackConfig: {
@@ -132,6 +131,19 @@ module.exports = {
       ]
     }
   }
+}
+```
+
+or create a webpack config, `webpack.config.js`:
+```js
+ module: {
+  rules: [
+    {
+      test: /\.jsx?$/,
+      exclude: /node_modules/,
+      loader: 'babel-loader'
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
add clarification when adding to an non-webpack project webpackConfig to clearly indicate what should be added to styleguide.config.js or to webpack.config.js